### PR TITLE
no redirect for 403 no permission

### DIFF
--- a/packages/xgen/utils/preset/axios.ts
+++ b/packages/xgen/utils/preset/axios.ts
@@ -28,7 +28,7 @@ axios.interceptors.response.use(
 			if (res.status && res.statusText) message.error(`${res.status} : ${res.statusText}`)
 		}
 
-		if (data?.code === 401 || data?.code === 403) {
+		if (data?.code === 401) {
 			if (
 				getPath(history.location.pathname) === '' ||
 				getPath(history.location.pathname) === '/' ||


### PR DESCRIPTION
It's ok for http 401 not authenticated and redirect to login url, but http 403 not authorized——should not redirect or redirect to permission apply url while not login url.